### PR TITLE
Fixing the full screen option for the mega menus #7

### DIFF
--- a/assets/js/models/mega-menu.js
+++ b/assets/js/models/mega-menu.js
@@ -21,7 +21,8 @@
 		defaults: {
 			item_id: null,
 			active: true,
-			widgets: null
+			widgets: null,
+			fullscreen: true,
 		},
 
 		initialize: function() {
@@ -41,7 +42,8 @@
 
 				this.set({
 					'widgets': new api.LSXMM.WidgetsCollection( orderedWidgets ),
-					'active': newObj.active
+					'active': newObj.active,
+					'fullscreen': newObj.fullscreen
 				});
 			} else {
 				this.set({

--- a/includes/class-lsxmm-frontend.php
+++ b/includes/class-lsxmm-frontend.php
@@ -375,7 +375,7 @@ class LSXMM_Frontend {
 		$saved_data = get_option( 'LSXMM_DATA' );
 		if ( $saved_data && array_key_exists( intval( $item_id ), $saved_data ) ) {
 			$mega_menu = $saved_data[ intval( $item_id ) ];
-			if ( false === $mega_menu['fullscreen'] ) {
+			if ( ! isset( $mega_menu['fullscreen'] ) || false === $mega_menu['fullscreen'] ) {
 				return false;
 			}
 			return true;


### PR DESCRIPTION
**Problem**
The checkbox that shows if a menu is set as fullscreen, never selects the checkbox.  even if the info is saved in the DB.

**Completed**
I have fixed the checkbox,  so now if you open a mega menu that was set as full screen,  it will show as checked.

**Testing**
- Open the customizer, and a menu that has a mega menu.   
- Set it as "fullscreen" and save.
- Refresh the page and open the same mega menu.
- The checkbox should be checked.

![Screenshot 2020-02-14 at 03 18 13](https://user-images.githubusercontent.com/1805603/74492779-a8326980-4ed8-11ea-9d3f-c3b5b6cd23df.png)
